### PR TITLE
[fix-typos] Fix typos in SquiggleCop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,5 +8,5 @@
 2. `dotnet nbgv tag`
 3. `git push origin {tag name}`
 4. Navigate to GitHub releases page and create release from tag
-5. (If desired) increment version (major or minor) in `//version.json > version`
+5. (If desired) increment version (major or minor) in `version.json > version`
 6. `git add . && git commit -m 'Bumping version' && git push`

--- a/src/Common/Sarif/README.md
+++ b/src/Common/Sarif/README.md
@@ -1,5 +1,5 @@
 SquiggleCop originally used the SARIF SDK (and ideally will again). However, the improvements of moving from
-`Newtonosft.Json` to `System.Text.Json` were too big to ignore. As a result, this directory contains a hand-rolled
+`Newtonsoft.Json` to `System.Text.Json` were too big to ignore. As a result, this directory contains a hand-rolled
 object model for SARIF files that contains only the members SquiggleCop needs (and ignores unmapped properties).
 
 https://github.com/microsoft/sarif-sdk/issues/1989 tracks migrating to STJ, at which point SquiggleCop should switch


### PR DESCRIPTION
## 🐝 Apiary Campaign: `fix-typos`

This PR was created automatically by an [Apiary](https://github.com/MattKotsenas/Apiary) campaign.

### What changed
The agent scanned documentation files (README.md, CONTRIBUTING.md, etc.) and fixed typos — correcting
misspellings, grammar, and punctuation without rewriting sentences or changing meaning.

### Why
Typos in documentation erode trust and readability. This campaign keeps docs clean across the repo.

### Review instructions
- Approve and merge if the changes look correct.
- To request changes, leave a comment containing `/fix-typos` and describe what needs fixing.
- Close the PR to abandon this repo's changes.