### PR TITLE
[fix-typos] Fix typos in SquiggleCop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-// TODO
+<!-- TODO -->
 
 ## How to release
 
@@ -8,5 +8,5 @@
 2. `dotnet nbgv tag`
 3. `git push origin {tag name}`
 4. Navigate to GitHub releases page and create release from tag
-5. (If desired) increment version (major or minor) in `//version.json > version`
+5. (If desired) increment version (major or minor) in `version.json > version`
 6. `git add . && git commit -m 'Bumping version' && git push`

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ And then run `git add --renormalize .` to update Git with the re-normalized file
 
 ---
 
-_Icon 'fractal' by Bohdan Burmich from [Noun Project](https://thenounproject.com/browse/icons/term/fractal/)
+_Icon 'fractal' by Bohdan Burmich from [the Noun Project](https://thenounproject.com/browse/icons/term/fractal/)
 (CC BY 3.0)_
 
 ## Frequently Asked Questions (FAQ)

--- a/README.md
+++ b/README.md
@@ -350,4 +350,4 @@ This is probably because you've set rules in an `.editorconfig`, so it only appl
 this is true even for the root .editorconfig, as projects can contain files from outside the repo / project root, and thus the
 compiler is correctly (albeit pedantically) reporting that the project _could_ have files where .editorconfig rules don't apply.
 
-If you want modify an analyzer rule project-wide, use a `.globalconfig` file. 
+If you want to modify an analyzer rule project-wide, use a `.globalconfig` file. 

--- a/docs/rules/SQ2001.md
+++ b/docs/rules/SQ2001.md
@@ -1,6 +1,6 @@
 # SQ2001: Multiple baseline files found in @(AdditionalFiles)
 
-The `@(AdditionalFiles) MSBuild item group has multiple SquiggleCop baseline files. The first match will be used.
+The `@(AdditionalFiles)` MSBuild item group has multiple SquiggleCop baseline files. The first match will be used.
 
 To resolve this issue, only specify a single baseline file. Consider using a
 [binary log](https://learn.microsoft.com/en-us/visualstudio/msbuild/obtaining-build-logs-with-msbuild?view=vs-2022#save-a-binary-log)

--- a/src/Common/Sarif/README.md
+++ b/src/Common/Sarif/README.md
@@ -1,5 +1,5 @@
 SquiggleCop originally used the SARIF SDK (and ideally will again). However, the improvements of moving from
-`Newtonosft.Json` to `System.Text.Json` were too big to ignore. As a result, this directory contains a hand-rolled
+`Newtonsoft.Json` to `System.Text.Json` were too big to ignore. As a result, this directory contains a hand-rolled
 object model for SARIF files that contains only the members SquiggleCop needs (and ignores unmapped properties).
 
 https://github.com/microsoft/sarif-sdk/issues/1989 tracks migrating to STJ, at which point SquiggleCop should switch


### PR DESCRIPTION
## 🐝 Apiary Campaign: `fix-typos`

This PR was created automatically by an [Apiary](https://github.com/MattKotsenas/Apiary) campaign.

### What changed
The agent scanned documentation files (README.md, CONTRIBUTING.md, etc.) and fixed typos — correcting
misspellings, grammar, and punctuation without rewriting sentences or changing meaning.

### Why
Typos in documentation erode trust and readability. This campaign keeps docs clean across the repo.

### Review instructions
- Approve and merge if the changes look correct.
- To request changes, leave a comment containing `/fix-typos` and describe what needs fixing.
- Close the PR to abandon this repo's changes.